### PR TITLE
Fixed typo

### DIFF
--- a/src/retention.py
+++ b/src/retention.py
@@ -105,7 +105,7 @@ class SimpleRetention(nn.Module):
         m = torch.arange(sequence_length).unsqueeze(0)
 
         # Broadcast self.gamma ** (n - m) with appropriate masking to set values where n < m to 0
-        D = (self.gamma ** (n - m)) * (n >= m).float()  #this results in some NaN when n is much larger than m
+        D = (self.gamma ** (n - m)) * (n >= m).float()  #this results in some NaN when m is much larger than n
         # fill the NaN with 0
         D[D != D] = 0
 


### PR DESCRIPTION
**Title:** Fix Comment Regarding Potential NaN in SimpleRetention

**Description:**

Hello,

While going through the `SimpleRetention` class in the module, I noticed a comment in the `_get_D` method that seemed to have a minor inconsistency. The comment in question mentions:

```python
# this results in some NaN when n is much larger than m
```

However, after analyzing the matrix operations, it appears that potential NaN values might arise when \( m \) (row index) is much larger than \( n \) (column index), specifically in the bottom-left triangle of the matrix.

This PR corrects the comment to:
```python
# this results in some NaN when m is much larger than n
```

Such a change might seem minor, but it aids in clarity and correctness for any developer reading the code in the future. 